### PR TITLE
Add interaction purification utility

### DIFF
--- a/python/interpret/utils/__init__.py
+++ b/python/interpret/utils/__init__.py
@@ -3,3 +3,4 @@
 
 from .all import *  # noqa: F401,F403
 from .distributed import *  # noqa: F401,F403
+from .purify import *

--- a/python/interpret/utils/purify.py
+++ b/python/interpret/utils/purify.py
@@ -1,0 +1,115 @@
+# Reduce a numpy matrix such that each row and column has mean 0.
+# Any offset is moved to the main effects. This recreates the 
+# Functional ANOVA decomposition.
+
+import numpy as np
+
+
+def purify_row(mat, marg, densities, i):
+    # Purify such that row i has mean 0.
+    try:
+        my_mean = np.average(mat[i, :], weights=densities[i, :])
+        marg[i] += my_mean
+        mat[i, :] -= my_mean
+    except ZeroDivisionError:
+        pass
+    return mat, marg
+
+
+def purify_col(mat, marg, densities, j):
+    # Purify such that column j has mean 0.
+    try:
+        my_mean = np.average(mat[:, j], weights=densities[:, j])
+        marg[j] += my_mean
+        mat[:, j] -= my_mean
+    except ZeroDivisionError:
+        pass
+    return mat, marg
+
+
+def purify_once(mat, densities=None, m1=None, m2=None, randomize=False):
+    # Purify ecah row and column of the matrix mat.
+    if densities is None:
+        densities = np.ones_like(mat)
+    # m1 along first axis
+    if m1 is None:
+        m1 = np.zeros((mat.shape[0], 1))
+
+    # m2 along second axis
+    if m2 is None:
+        m2 = np.zeros((mat.shape[1], 1))
+
+    if randomize: # randomize each row/col selection rather than in-order
+        nonzero_rows = set(list(range(mat.shape[0])))
+        nonzero_cols = set(list(range(mat.shape[1])))
+        for iteration in range(mat.shape[0] + mat.shape[1]):
+            if np.random.binomial(1, 0.5) and len(nonzero_rows) > 0:
+                i = np.random.choice(list(nonzero_rows)) # todo: maybe slow
+                nonzero_rows.remove(i)
+                mat, m1 = purify_row(mat, m1, densities, i)
+            elif len(nonzero_cols) > 0:
+                j = np.random.choice(list(nonzero_cols))
+                nonzero_cols.remove(j)
+                mat, m2 = purify_col(mat, m2, densities, j)
+                
+    # Fix each row mean
+    for i in range(mat.shape[0]):
+        mat, m1 = purify_row(mat, m1, densities, i)
+    # Fix each col mean
+    for j in range(mat.shape[1]):
+        mat, m2 = purify_col(mat, m2, densities, j)
+        
+    return np.squeeze(m1), np.squeeze(m2), mat
+
+
+def calc_row_means(mat, densities):
+    means = []
+    for i in range(mat.shape[0]):
+        try:
+            means.append(np.average(mat[i, :], weights=densities[i, :]))
+        except ZeroDivisionError:
+            means.append(0)
+    return means
+
+
+def calc_col_means(mat, densities):
+    means = []
+    for j in range(mat.shape[1]):
+        try:
+            means.append(np.average(mat[:, j], weights=densities[:, j]))
+        except ZeroDivisionError:
+            means.append(0)
+    return means
+
+
+def purify(mat, densities=None, verbose=False, tol=1e-6, randomize=False):
+    # Move the means of the rows and columns into the marginal effects, 
+    # respecting sample density.
+    # If randomize is True, then the order of row and columns is randomly 
+    # selected; otherwise they are processed in order.
+
+    if densities is None: # Use a uniform density
+        densities = np.ones_like(mat)
+    i = 1
+    m1, m2, mat = purify_once(mat, densities)
+    row_means = calc_row_means(mat, densities)
+    col_means = calc_col_means(mat, densities)
+    max_row = np.max(np.abs(row_means))
+    max_col = np.max(np.abs(col_means))
+    while max_row > tol or max_col > tol:
+        i += 1
+        if verbose:
+            print(i, max_row, max_col)
+        m1, m2, mat = purify_once(mat, densities, m1, m2, randomize)
+        row_means = calc_row_means(mat, densities)
+        col_means = calc_col_means(mat, densities)
+        max_row = np.max(np.abs(row_means))
+        max_col = np.max(np.abs(col_means))
+    # Center m1 and m2
+    intercept = 0.
+    intercept += np.average(m1, weights=np.sum(densities, axis=1))
+    m1 -= np.average(m1, weights=np.sum(densities, axis=1))
+    intercept += np.average(m2, weights=np.sum(densities, axis=0))
+    m2 -= np.average(m2, weights=np.sum(densities, axis=0))
+    return intercept, m1, m2, mat, i
+

--- a/python/interpret/utils/test/test_purify.py
+++ b/python/interpret/utils/test/test_purify.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2019 Microsoft Corporation
+# Distributed under the MIT software license
+
+import pytest
+import numpy as np
+from .. import purify_row, purify_col, purify_once, calc_row_means, calc_col_means, purify
+
+n_rows = 10
+n_cols = 15
+
+
+def test_purify_row():
+    # Test Base Case of all Zeros.
+    raw_mat = np.array([
+        np.array([0, 0]),
+        np.array([0, 0])
+    ], dtype=np.float64)
+    raw_marg = np.array([0, 0], dtype=np.float64)
+    densities = np.ones_like(raw_mat)
+    pure_mat, pure_marg = purify_row(raw_mat.copy(), raw_marg.copy(), densities, 0)
+    assert np.all(np.isclose(pure_mat, raw_mat, atol=1e-10))
+    assert np.all(np.isclose(pure_marg, raw_marg, atol=1e-10))
+
+    # Test Random Matrix.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    raw_marg = np.random.uniform(-1, 1, size=(n_rows, 1))
+    densities = np.random.uniform(0, 1, size=raw_mat.shape)
+    for i in range(n_rows):
+        pure_mat, pure_marg = purify_row(raw_mat.copy(), raw_marg.copy(), densities, i)
+        assert np.abs(np.average(pure_mat[i, :], weights=densities[i, :])) < 1e-10
+        assert np.all(np.isclose(pure_marg[i], raw_marg[i] + np.average(raw_mat[i, :],
+            weights=densities[i, :]), atol=1e-10))
+
+
+def test_purify_col():
+    # Test Base Case of all Zeros.
+    raw_mat = np.array([
+        np.array([0, 0]),
+        np.array([0, 0])
+    ], dtype=np.float64)
+    raw_marg = np.array([0, 0], dtype=np.float64)
+    densities = np.ones_like(raw_mat)
+    pure_mat, pure_marg = purify_col(raw_mat.copy(), raw_marg.copy(), densities, 0)
+    assert np.all(np.isclose(pure_mat, raw_mat, atol=1e-10))
+    assert np.all(np.isclose(pure_marg, raw_marg, atol=1e-10))
+
+    # Test Random Matrix.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    raw_marg = np.random.uniform(-1, 1, size=(n_cols, 1))
+    densities = np.random.uniform(0, 1, size=raw_mat.shape)
+    for j in range(n_cols):
+        pure_mat, pure_marg = purify_col(raw_mat.copy(), raw_marg.copy(), densities, j)
+        assert np.abs(np.average(pure_mat[:, j], weights=densities[:, j])) < 1e-10
+        assert np.all(np.isclose(pure_marg[j], raw_marg[j] + np.average(raw_mat[:, j], weights=densities[:, j]), atol=1e-10))
+
+
+def test_purify():
+    # Test Base Case of all Zeros.
+    raw_mat = np.array([
+        np.array([0, 0]),
+        np.array([0, 0])
+    ], dtype=np.float64)
+    densities = np.ones_like(raw_mat)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=False)
+    assert np.abs(intercept) < 1e-10
+    assert np.all(np.isclose(pure_mat, raw_mat, atol=1e-10))
+    assert np.all(np.isclose(pure_marg1, 0, atol=1e-10))
+    assert np.all(np.isclose(pure_marg2, 0, atol=1e-10))
+
+    # Test with random matrix and uniform density.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    densities = np.ones_like(raw_mat)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=False)
+    for i in range(n_rows):
+        assert np.abs(np.average(pure_mat[i, :], weights=densities[i, :])) < 1e-10
+        assert np.all(np.isclose(pure_marg1[i]+intercept, np.average(raw_mat[i, :], weights=densities[i, :]), atol=1e-10))
+    for j in range(n_cols):
+        assert np.abs(np.average(pure_mat[:, j], weights=densities[:, j])) < 1e-10
+        assert np.all(np.isclose(pure_marg2[j]+intercept, np.average(raw_mat[:, j], weights=densities[:, j]), atol=1e-10))
+    assert n_iter == 1 # Always takes a single iteration with uniform density.
+    
+    # Test with random matrix and random density.
+    # Test with random matrix and uniform density.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    densities = np.random.uniform(0, 100, size=raw_mat.shape)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=False)
+    for i in range(n_rows):
+        assert np.abs(np.average(pure_mat[i, :], weights=densities[i, :])) < 1e-10
+    for j in range(n_cols):
+        assert np.abs(np.average(pure_mat[:, j], weights=densities[:, j])) < 1e-10
+    # Can't easily predict marginal values when non-uniform density.
+
+
+def test_purify_randomize():
+    # Randomize should not change the results
+    # Test Base Case of all Zeros.
+    raw_mat = np.array([
+        np.array([0, 0]),
+        np.array([0, 0])
+    ], dtype=np.float64)
+    densities = np.ones_like(raw_mat)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=True)
+    assert np.abs(intercept) < 1e-10
+    assert np.all(np.isclose(pure_mat, raw_mat, atol=1e-10))
+    assert np.all(np.isclose(pure_marg1, 0, atol=1e-10))
+    assert np.all(np.isclose(pure_marg2, 0, atol=1e-10))
+
+    # Test with random matrix and uniform density.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    densities = np.ones_like(raw_mat)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=True)
+    for i in range(n_rows):
+        assert np.abs(np.average(pure_mat[i, :], weights=densities[i, :])) < 1e-10
+        assert np.all(np.isclose(pure_marg1[i]+intercept, np.average(raw_mat[i, :], weights=densities[i, :]), atol=1e-10))
+    for j in range(n_cols):
+        assert np.abs(np.average(pure_mat[:, j], weights=densities[:, j])) < 1e-10
+        assert np.all(np.isclose(pure_marg2[j]+intercept, np.average(raw_mat[:, j], weights=densities[:, j]), atol=1e-10))
+    
+    # Test with random matrix and random density.
+    # Test with random matrix and uniform density.
+    raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))
+    densities = np.random.uniform(0, 100, size=raw_mat.shape)
+    intercept, pure_marg1, pure_marg2, pure_mat, n_iter = purify(raw_mat.copy(), densities=densities, tol=1e-10, randomize=True)
+    for i in range(n_rows):
+        assert np.abs(np.average(pure_mat[i, :], weights=densities[i, :])) < 1e-10
+    for j in range(n_cols):
+        assert np.abs(np.average(pure_mat[:, j], weights=densities[:, j])) < 1e-10
+    # Can't easily predict marginal values when non-uniform density.
+
+
+def test_purify_identifiable():
+    # Test whether perturbing a model, then purifying it recovers the original model.
+    def helper(randomize):
+        raw_mat = np.random.uniform(-1, 1, size=(n_rows, n_cols))*np.random.binomial(1, 0.9, size=(n_rows, n_cols))
+        densities = np.random.uniform(1, 100, size=(n_rows, n_cols))
+        intercept, m1, m2, pure_mat, n_iters = purify(raw_mat.copy(),
+                densities=densities, tol=1e-10, randomize=randomize)
+        m1_perturbed = m1.copy()
+        m2_perturbed = m2.copy()
+        mat_perturbed = pure_mat.copy()
+        for i in range(n_rows):
+            val = np.random.normal()
+            m1_perturbed[i] += val
+            mat_perturbed[i, :] -= val
+        for j in range(n_cols):
+            val = np.random.normal()
+            m2_perturbed[j] += val
+            mat_perturbed[:, j] -= val
+        intercept2, m12, m22, pure_mat2, n_iters2 = purify(mat_perturbed,
+                densities=densities, tol=1e-10, randomize=randomize)
+        m12 += m1_perturbed
+        m22 += m2_perturbed
+
+        # After centering, the purified model should be the same.
+        m12 -= np.average(m12, weights=np.sum(densities, axis=1))
+        m22 -= np.average(m22, weights=np.sum(densities, axis=0))
+
+        assert np.all(np.isclose(m1, m12, atol=1e-10))
+        assert np.all(np.isclose(m2, m22, atol=1e-10))
+        assert np.all(np.isclose(pure_mat, pure_mat2, atol=1e-10))
+
+    helper(False)
+    helper(True)


### PR DESCRIPTION
In additive models, effect sizes can be freely moved between the matrix representing interaction effects and the main effects.  To make sure we are consistent when interpreting interaction effects, it would be great to present models in an identifiable form. We can accomplish this goal by "mass-moving" any interaction effects with non-zero row means or non-zero column means into the corresponding main effect plots.

This PR includes a utility file purify.py and associated tests to perform "mass-moving" on numpy arrays. It is not currently integrated with the EBM API.