### PR TITLE
Fix bug to correctly set VisualizeProvider ip address and port

### DIFF
--- a/python/interpret-core/interpret/provider/test/test_providers.py
+++ b/python/interpret-core/interpret/provider/test/test_providers.py
@@ -46,8 +46,16 @@ def test_azureml_provider():
 
 def test_auto_visualize_provider(example_explanation):
     # NOTE: We know this environment is going to use Dash.
-    provider = AutoVisualizeProvider(addr=("127.0.0.1", "7200"))
+    from ...visual.dashboard import AppRunner
+    ip = "127.0.0.1"
+    port = "7200"
+    app_runner = AppRunner(addr=(ip, port))
+    provider = AutoVisualizeProvider(app_runner=app_runner)
     provider.render(example_explanation)
+
+    # Assert that the address is passed into Dash
+    assert provider.provider.app_runner.ip == ip
+    assert provider.provider.app_runner.port == port
     provider.provider.app_runner.stop()
 
 
@@ -65,7 +73,12 @@ def test_inline_provider(example_explanation):
 
 
 def test_dash_provider(example_explanation):
-    provider = DashProvider(addr=("127.0.0.1", "7201"))
+    ip = "127.0.0.1"
+    port = "7201"
+    provider = DashProvider.from_address(addr=(ip, port))
+    assert provider.app_runner.ip == ip
+    assert provider.app_runner.port == port
+
     provider.render(example_explanation)
     link = provider.link(example_explanation)
     assert link is not None

--- a/python/interpret-core/interpret/test/test_interactive.py
+++ b/python/interpret-core/interpret/test/test_interactive.py
@@ -8,6 +8,7 @@ from ..visual.interactive import (
     status_show_server,
 )
 from ..visual.interactive import show, init_show_server, preserve
+from ..visual import interactive
 from .utils import synthetic_classification
 from ..glassbox import LogisticRegression, DecisionListClassifier
 from .. import show_link
@@ -107,6 +108,12 @@ def test_init_show_server(explanation):
 
     init_show_server(addr=target_addr, base_url=base_url, use_relative_links=False)
     show(explanation)
+
+    # Assert that the address and url are passed to Dash
+    provider = interactive.visualize_provider.provider
+    assert provider.app_runner.port == port
+    assert provider.app_runner.base_url == base_url
+
     url = show_link(explanation)
 
     try:

--- a/python/interpret-core/interpret/visual/interactive.py
+++ b/python/interpret-core/interpret/visual/interactive.py
@@ -137,7 +137,8 @@ def show(explanation, key=-1, **kwargs):
 
         # Set default render if needed
         if this.visualize_provider is None:
-            this.visualize_provider = AutoVisualizeProvider()
+            # If the server has been initialized already, use it
+            this.visualize_provider = AutoVisualizeProvider(app_runner=this.app_runner)
 
         # Render
         this.visualize_provider.render(explanation, key=key, **kwargs)


### PR DESCRIPTION
The ip address and port set through interactive.set_show_addr()
are not passed to AutoVisualizeProvider (and DashProvider). As a result,
interactive.show() does not render at the user defined address.

Also add unit tests to assert that the ip and port are set correctly.