### PR TITLE
add stack trace information to extension system error

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ show(ebm_global)
 ```
 ![Global Explanation Image](examples/python/assets/readme_ebm_global_specific.PNG?raw=true)
 
+The graphs are the entire model.  For regression, sum the scores to get your prediction.  For classification, sum the scores and take the softmax.  Nothing is hidden.
+
 <br/>
 
 Understand individual predictions

--- a/README.md
+++ b/README.md
@@ -489,9 +489,9 @@ We also build on top of many great packages. Please check them out!
 ## External links
 
 - [A gentle introduction to GA2Ms, a white box model](https://blog.fiddler.ai/2019/06/a-gentle-introduction-to-ga2ms-a-white-box-model)
+- [On Model Explainability: From LIME, SHAP, to Explainable Boosting](https://everdark.github.io/k9/notebooks/ml/model_explain/model_explain.nb.html)
 - [Benchmarking and MLI experiments on the Adult dataset](https://github.com/sayakpaul/Benchmarking-and-MLI-experiments-on-the-Adult-dataset/blob/master/Benchmarking_experiments_on_the_Adult_dataset_and_interpretability.ipynb)
 - [Dealing with Imbalanced Data (Mortgage loans defaults)](https://mikewlange.github.io/ImbalancedData-/index.html)
-- [On Model Explainability: From LIME, SHAP, to Explainable Boosting](https://everdark.github.io/k9/notebooks/ml/model_explain/model_explain.nb.html)
 - [Kaggle PGA Tour analysis by GAM](https://www.kaggle.com/juyamagu/pga-tour-analysis-by-gam)
 
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ show([logistic_regression, decision_tree])
 ## Roadmap
 
 Currently we're working on:
-- R language interface
+- R language interface (R is currently a WIP. Basic EBM classification can be done via the ebm_classify & ebm_predict_proba functions, but the predictions are a bit less accurate than in python. No plotting included yet, but other R plotting tools can do a basic job visualizing EBM models)
 - Missing Values Support
 - Improved Categorical Encoding
 - Interaction effect purification (see citations for details)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ show(ebm_global)
 ```
 ![Global Explanation Image](examples/python/assets/readme_ebm_global_specific.PNG?raw=true)
 
-The graphs themselves are the entire model.  For regression, sum the scores to get your prediction.  For classification, sum the scores and take the softmax.  Nothing is hidden.  You can see everything.
+The graphs are the entire model.<sup>[*](#intercept-footnote)</sup>  For regression, sum the scores from each graph to get your prediction.  For classification, sum the scores and take the softmax.  Nothing is hidden.  You can inspect everything.
+
+<p align="right"><i>
+   <a name="intercept-footnote">*</a>A single global intercept score is also required for computation, but not visualization
+</i></p>
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ show(ebm_global)
 ```
 ![Global Explanation Image](examples/python/assets/readme_ebm_global_specific.PNG?raw=true)
 
-The graphs are the entire model.  For regression, sum the scores to get your prediction.  For classification, sum the scores and take the softmax.  Nothing is hidden.
+The graphs themselves are the entire model.  For regression, sum the scores to get your prediction.  For classification, sum the scores and take the softmax.  Nothing is hidden.  You can see everything.
 
 <br/>
 
@@ -484,6 +484,16 @@ We also build on top of many great packages. Please check them out!
   
   <hr/>
 </details>
+
+
+## External links
+
+- [A gentle introduction to GA2Ms, a white box model](https://blog.fiddler.ai/2019/06/a-gentle-introduction-to-ga2ms-a-white-box-model)
+- [Benchmarking and MLI experiments on the Adult dataset](https://github.com/sayakpaul/Benchmarking-and-MLI-experiments-on-the-Adult-dataset/blob/master/Benchmarking_experiments_on_the_Adult_dataset_and_interpretability.ipynb)
+- [Dealing with Imbalanced Data (Mortgage loans defaults)](https://mikewlange.github.io/ImbalancedData-/index.html)
+- [On Model Explainability: From LIME, SHAP, to Explainable Boosting](https://everdark.github.io/k9/notebooks/ml/model_explain/model_explain.nb.html)
+- [PGA Tour analysis by GAM](https://www.kaggle.com/juyamagu/pga-tour-analysis-by-gam)
+
 
 ## Contact us
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ We also build on top of many great packages. Please check them out!
 - [Benchmarking and MLI experiments on the Adult dataset](https://github.com/sayakpaul/Benchmarking-and-MLI-experiments-on-the-Adult-dataset/blob/master/Benchmarking_experiments_on_the_Adult_dataset_and_interpretability.ipynb)
 - [Dealing with Imbalanced Data (Mortgage loans defaults)](https://mikewlange.github.io/ImbalancedData-/index.html)
 - [Kaggle PGA Tour analysis by GAM](https://www.kaggle.com/juyamagu/pga-tour-analysis-by-gam)
+- [Interpretable Prediction of Goals in Soccer](http://statsbomb.com/wp-content/uploads/2019/10/decroos-interpretability-statsbomb.pdf)
 
 
 ## Contact us

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ We also build on top of many great packages. Please check them out!
 - [Benchmarking and MLI experiments on the Adult dataset](https://github.com/sayakpaul/Benchmarking-and-MLI-experiments-on-the-Adult-dataset/blob/master/Benchmarking_experiments_on_the_Adult_dataset_and_interpretability.ipynb)
 - [Dealing with Imbalanced Data (Mortgage loans defaults)](https://mikewlange.github.io/ImbalancedData-/index.html)
 - [On Model Explainability: From LIME, SHAP, to Explainable Boosting](https://everdark.github.io/k9/notebooks/ml/model_explain/model_explain.nb.html)
-- [PGA Tour analysis by GAM](https://www.kaggle.com/juyamagu/pga-tour-analysis-by-gam)
+- [Kaggle PGA Tour analysis by GAM](https://www.kaggle.com/juyamagu/pga-tour-analysis-by-gam)
 
 
 ## Contact us

--- a/python/interpret-core/interpret/ext/extension_utils.py
+++ b/python/interpret-core/interpret/ext/extension_utils.py
@@ -5,6 +5,7 @@ import logging
 import pkg_resources
 import re
 from warnings import warn
+import traceback
 
 
 module_logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def load_class_extensions(current_module, extension_key, extension_class_validat
 
         except Exception as e:  # pragma: no cover
             msg = "Failure while loading {}. Failed to load entrypoint {} with exception {}.".format(
-                extension_key, entrypoint, e
+                extension_key, entrypoint, ''.join(traceback.format_exception(type(e), e, e.__traceback__))
             )
             module_logger.warning(msg)
 


### PR DESCRIPTION
Add stack trace information to extension system error

Currently the stack trace is not printed which sometimes makes it difficult to debug errors on remote compute (especially for cryptic error messages) - seeing the stack trace should make it easier to determine where specifically the error is coming from in the codebase.

Example of error without fix:
C:\Users\ilmat\AppData\Local\Continuum\Miniconda3\envs\sh\lib\site-packages\interpret\ext\extension_utils.py:70: UserWarning: Failure while loading interpret_ext_blackbox. Failed to load entrypoint KernelExplainer = interpret_community.shap:KernelExplainer with exception
 (interpret-core 0.1.20 (c:\users\ilmat\appdata\local\continuum\miniconda3\envs\sh\lib\site-packages), Requirement.parse('interpret-core[required]==0.1.19')).

Example of new error with this fix:
C:\interpret\python\interpret-core\interpret\ext\extension_utils.py:71: UserWarning: Failure while loading interpret_ext_blackbox. Failed to load entrypoint TabularExplainer = interpret_community:TabularExplainer with exception Traceback (most recent call last):
  File "C:\interpret\python\interpret-core\interpret\ext\extension_utils.py", line 45, in load_class_extensions
    extension_class = entrypoint.load()
  File "C:\Users\ilmat\AppData\Local\Continuum\Miniconda3\envs\sh\lib\site-packages\pkg_resources\__init__.py", line 2443, in load
    self.require(*args, **kwargs)
  File "C:\Users\ilmat\AppData\Local\Continuum\Miniconda3\envs\sh\lib\site-packages\pkg_resources\__init__.py", line 2466, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "C:\Users\ilmat\AppData\Local\Continuum\Miniconda3\envs\sh\lib\site-packages\pkg_resources\__init__.py", line 792, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (interpret-core 0.1.16 (c:\interpret\python\interpret-core), Requirement.parse('interpret-core[required]==0.1.19'))

