### PR TITLE
fix environment detection for azureml notebook VM case

### DIFF
--- a/python/interpret-core/interpret/utils/environment.py
+++ b/python/interpret-core/interpret/utils/environment.py
@@ -78,7 +78,8 @@ def _detect_azure_notebook():
 
 
 def _detect_azureml_notebook_vm():
-    return "AZUREML_NB_PATH" in os.environ
+    nbvm_file_path = "/mnt/azmnt/.nbvm"
+    return (os.path.exists(nbvm_file_path) and os.path.isfile(nbvm_file_path))
 
 
 def _detect_vscode():


### PR DESCRIPTION
fix environment detection for azureml notebook VM case

For AzureML notebook VM case, we just need to check if this file exists to detect that we are in this environment:
/mnt/azmnt/.nbvm