### PR TITLE
Make multiple show example more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ show(ebm_local)
 
 <br/>
 
-And if you have multiple models, compare them
+And if you have multiple model explanations, compare them
 ```python
-show([logistic_regression, decision_tree])
+show([logistic_regression_global, decision_tree_global])
 ```
 ![Dashboard Image](./examples/python/assets/readme_dashboard.PNG?raw=true)
 <br/>


### PR DESCRIPTION
The change should make it more obvious that you can pass the explanations of multiple models to the show function, not the actual models.