### PR TITLE
Adding predict_proba_and_explain to ExplainableBoostingClassifier

### DIFF
--- a/python/interpret-core/interpret/glassbox/ebm/ebm.py
+++ b/python/interpret-core/interpret/glassbox/ebm/ebm.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019 Microsoft Corporation
 # Distributed under the MIT software license
 
-from typing import DefaultDict
 
+from typing import DefaultDict
 from ...utils import gen_perf_dicts
 from .utils import EBMUtils
 from .internal import NativeHelper, Native
@@ -138,7 +138,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
             feature_names: Feature names as list.
             feature_types: Feature types as list, for example "continuous" or "categorical".
             max_bins: Max number of bins to process numeric features.
-            binning: Strategy to compute bins: "quantile", "quantile_humanized", "uniform".
+            binning: Strategy to compute bins: "quantile", "quantile_humanized", "uniform". 
             missing_str: By default np.nan values are missing for all datatypes. Setting this parameter changes the string representation for missing
         """
         self.feature_names = feature_names
@@ -200,24 +200,24 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                         is_humanized = 1
 
                     (
-                        cuts,
-                        count_missing,
-                        min_val,
-                        max_val,
+                        cuts, 
+                        count_missing, 
+                        min_val, 
+                        max_val, 
                     ) = native.generate_quantile_cuts(
-                        col_data,
-                        min_samples_bin,
-                        is_humanized,
+                        col_data, 
+                        min_samples_bin, 
+                        is_humanized, 
                         self.max_bins - 2, # one bin for missing, and # of cuts is one less again
                     )
                 elif self.binning == "uniform":
                     (
-                        cuts,
-                        count_missing,
-                        min_val,
+                        cuts, 
+                        count_missing, 
+                        min_val, 
                         max_val,
                     ) = native.generate_uniform_cuts(
-                        col_data,
+                        col_data, 
                         self.max_bins - 2, # one bin for missing, and # of cuts is one less again
                     )
                 else:
@@ -229,7 +229,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
 
                 if count_missing != 0:
                     col_data = col_data[~np.isnan(col_data)]
-
+                
                 self.col_bin_counts_.append(bin_counts)
                 self.col_bin_edges_[col_idx] = cuts
                 self.col_min_[col_idx] = min_val
@@ -284,7 +284,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                 cuts = self.col_bin_edges_[col_idx]
 
                 discretized = native.discretize(col_data, cuts)
-
+                
                 X_new[:, col_idx] = discretized
 
             elif col_type == "ordinal":
@@ -306,7 +306,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                 X_new[:, col_idx] = np.fromiter(
                     (mapping.get(x, unknown_constant) for x in col_data), dtype=np.int64, count=X.shape[0]
                 )
-
+                
 
         return X_new.astype(np.int64)
 
@@ -433,7 +433,7 @@ class BaseCoreEBM:
             )
         else:
             X_pair_train, X_pair_val = None, None
-
+              
         # Build EBM allocation code
 
         # scikit-learn returns an np.array for classification and
@@ -479,8 +479,8 @@ class BaseCoreEBM:
         ) = NativeHelper.cyclic_gradient_boost(
             model_type=self.model_type,
             n_classes=self.n_classes_,
-            features_categorical = self.features_categorical,
-            features_bin_count = self.features_bin_count,
+            features_categorical = self.features_categorical, 
+            features_bin_count = self.features_bin_count, 
             feature_groups=main_feature_groups,
             X_train=X_train,
             y_train=y_train,
@@ -491,7 +491,7 @@ class BaseCoreEBM:
             w_val=w_val,
             scores_val=None,
             n_inner_bags=self.inner_bags,
-            generate_update_options=Native.GenerateUpdateOptions_Default,
+            generate_update_options=Native.GenerateUpdateOptions_Default, 
             learning_rate=self.learning_rate,
             min_samples_leaf=self.min_samples_leaf,
             max_leaves=self.max_leaves,
@@ -521,8 +521,8 @@ class BaseCoreEBM:
                 iter_feature_groups=iter_feature_groups,
                 model_type=self.model_type,
                 n_classes=self.n_classes_,
-                features_categorical = self.pair_features_categorical,
-                features_bin_count = self.pair_features_bin_count,
+                features_categorical = self.pair_features_categorical, 
+                features_bin_count = self.pair_features_bin_count, 
                 X=X_pair,
                 y=y_train,
                 w=w_train,
@@ -560,8 +560,8 @@ class BaseCoreEBM:
         ) = NativeHelper.cyclic_gradient_boost(
             model_type=self.model_type,
             n_classes=self.n_classes_,
-            features_categorical = self.pair_features_categorical,
-            features_bin_count = self.pair_features_bin_count,
+            features_categorical = self.pair_features_categorical, 
+            features_bin_count = self.pair_features_bin_count, 
             feature_groups=inter_indices,
             X_train=X_pair_train,
             y_train=y_train,
@@ -572,7 +572,7 @@ class BaseCoreEBM:
             w_val=w_val,
             scores_val=scores_val,
             n_inner_bags=self.inner_bags,
-            generate_update_options=Native.GenerateUpdateOptions_Default,
+            generate_update_options=Native.GenerateUpdateOptions_Default, 
             learning_rate=self.learning_rate,
             min_samples_leaf=self.min_samples_leaf,
             max_leaves=self.max_leaves,

--- a/python/interpret-core/interpret/glassbox/ebm/test/test_ebm.py
+++ b/python/interpret-core/interpret/glassbox/ebm/test/test_ebm.py
@@ -339,6 +339,29 @@ def test_ebm_adult():
 
     _smoke_test_explanations(global_exp, local_exp, 6000)
 
+@pytest.mark.visual
+@pytest.mark.slow
+def test_ebm_predict_proba_and_explain():
+    data = adult_classification()
+    X_tr = data["train"]["X"]
+    y_tr = data["train"]["y"]
+    X_te = data["test"]["X"]
+
+    clf = ExplainableBoostingClassifier(n_jobs=-2, interactions=3)
+    clf.fit(X_tr, y_tr)
+
+    probabilities_orig = clf.predict_proba(X_te)
+    probabilities, explanations = clf.predict_proba_and_explain(X_te)
+
+    assert np.allclose(probabilities_orig, probabilities)
+
+    # TODO: Make a better test to ensure explanations are correct
+    explanations_sum_orig = clf.decision_function(X_te)
+    explanations_sum = np.sum(explanations, axis=1)
+    explanations_sum += clf.intercept_
+
+    assert np.allclose(explanations_sum_orig, explanations_sum)
+
 def test_ebm_sample_weight():
     data = adult_classification()
     X_train = data["train"]["X"][:, [0, 1]]

--- a/python/interpret-core/interpret/glassbox/ebm/utils.py
+++ b/python/interpret-core/interpret/glassbox/ebm/utils.py
@@ -189,6 +189,37 @@ class EBMUtils:
         return score_vector
 
     @staticmethod
+    def decision_function_and_explain(X, X_pair, feature_groups, model, intercept):
+        if X.ndim == 1:
+            X = X.reshape(X.shape[0], 1)
+
+        # Initialize empty vector for predictions and explanations
+        if isinstance(intercept, numbers.Number) or len(intercept) == 1:
+            score_vector = np.empty(X.shape[1])
+        else:
+            score_vector = np.empty((X.shape[1], len(intercept)))
+
+        np.copyto(score_vector, intercept)
+
+        n_interactions = sum(len(fg) > 1 for fg in feature_groups)
+        explanations = np.empty((X.shape[1], X.shape[0] + n_interactions))
+
+        # Generate prediction scores
+        scores_gen = EBMUtils.scores_by_feature_group(
+            X, X_pair, feature_groups, model
+        )
+        for set_idx, _, scores in scores_gen:
+            score_vector += scores
+            explanations[:, set_idx] = scores
+
+        if not np.all(np.isfinite(score_vector)):  # pragma: no cover
+            msg = "Non-finite values present in log odds vector."
+            log.error(msg)
+            raise Exception(msg)
+
+        return score_vector, explanations
+
+    @staticmethod
     def classifier_predict_proba(X, X_pair, feature_groups, model, intercept):
         log_odds_vector = EBMUtils.decision_function(
             X, X_pair, feature_groups, model, intercept
@@ -211,9 +242,41 @@ class EBMUtils:
         return classes[np.argmax(log_odds_vector, axis=1)]
 
     @staticmethod
+    def classifier_predict_and_explain(X, X_pair, feature_groups, model, intercept, classes, output='probabilities'):
+        scores_vector, explanations = EBMUtils.decision_function_and_explain(
+            X,
+            X_pair,
+            feature_groups,
+            model,
+            intercept
+        )
+
+        if output == 'probabilities':
+            if scores_vector.ndim == 1:
+                scores_vector = np.c_[np.zeros(scores_vector.shape), scores_vector]
+            return softmax(scores_vector), explanations
+        elif output == 'labels':
+            if scores_vector.ndim == 1:
+                scores_vector = np.c_[np.zeros(scores_vector.shape), scores_vector]
+            return classes[np.argmax(scores_vector, axis=1)], explanations
+        else:
+            return scores_vector, explanations
+
+    @staticmethod
     def regressor_predict(X, X_pair, feature_groups, model, intercept):
         scores = EBMUtils.decision_function(X, X_pair, feature_groups, model, intercept)
         return scores
+
+    @staticmethod
+    def regressor_predict_and_explain(X, X_pair, feature_groups, model, intercept):
+        scores, explanations = EBMUtils.decision_function_and_explain(
+            X,
+            X_pair,
+            feature_groups,
+            model,
+            intercept
+        )
+        return scores, explanations
 
     @staticmethod
     def gen_feature_group_name(feature_idxs, col_names):


### PR DESCRIPTION
This new method decreases runtime of a `predict` + `explain_local` by 4x by reducing the number of calls to calculate scores and returning explanations in a raw format (i.e. a numpy array).