### PR TITLE
Fix type annotation

### DIFF
--- a/python/powerlift/src/powerlift/bench/store.py
+++ b/python/powerlift/src/powerlift/bench/store.py
@@ -17,7 +17,7 @@ Near future support:
 import pytz
 import base64
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, Iterable, List, Optional, Type
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Type
 import random
 import random
 from powerlift.db.actions import delete_db, create_db
@@ -371,7 +371,7 @@ class Store:
             return None
         return self.from_db_trial(trial_orm)
 
-    def get_or_create_experiment(self, name: str, description: str) -> int:
+    def get_or_create_experiment(self, name: str, description: str) -> Tuple[int, bool]:
         """Get or create experiment keyed by name."""
         created = False
         exp_orm = self._session.query(db.Experiment).filter_by(name=name).one_or_none()


### PR DESCRIPTION
Signed-off-by: Daiki Katsuragawa <50144563+daikikatsuragawa@users.noreply.github.com>

The return value of get_or_create_experiment is follows.

```python
        return exp_orm.id, created
```

https://github.com/daikikatsuragawa/interpret/blob/f719fe397a62dd964bdbd95c1df0ee44e540f951/python/powerlift/src/powerlift/bench/store.py#L387



The type hints are matched to this.

```python
    def get_or_create_experiment(self, name: str, description: str) -> Tuple[int, bool]:
```

https://github.com/daikikatsuragawa/interpret/blob/f719fe397a62dd964bdbd95c1df0ee44e540f951/python/powerlift/src/powerlift/bench/store.py#L374