### PR TITLE
new methods

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2208,8 +2208,8 @@ class EBMModel(BaseEstimator):
                 floats whose i-th element corresponds to the i-th element of the
                 ``.term_*_`` attributes (e.g., ``.term_names_``).
             remove_nil_terms: Logical indicating whether or not to automatically
-                remove all terms that provide zero contribution to the fit 
-                (e.g., any term with a weight of zero).
+                remove all terms that are given a weight of zero; terms with a
+                weight of zero provide zero contribution to the fit.
 
         Returns: 
             Itself.
@@ -2262,8 +2262,8 @@ class EBMModel(BaseEstimator):
 
         # Delete "nil" terms (i.e., terms providing zero contribution to the fit)
         if remove_nil_terms:  # should automatically catch zero weight terms
-            # Grab indices of terms with zero contribution
-            term_list = np.where(self.term_importances() == 0)[0].tolist()
+            # Delete components that have a weight of zero
+            term_list = np.where(weights == 0)[0].tolist()
             return self.remove_terms(term_list)
         else:
             return self

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2146,10 +2146,10 @@ class EBMModel(BaseEstimator):
         return self
 
     def remove_terms(self, terms):
-        """Removes terms (and their associated components) from a fitted EBM. Note 
-        that this will change the structure (i.e., by removing the specified 
+        """Removes terms (and their associated components) from a fitted EBM. Note
+        that this will change the structure (i.e., by removing the specified
         indices) of the following components of ``self``: ``term_features_``,
-        ``term_names_``, ``term_scores_``, ``bagged_scores_``, 
+        ``term_names_``, ``term_scores_``, ``bagged_scores_``,
         ``standard_deviations_``, and ``bin_weights_``.
 
         Args:
@@ -2161,12 +2161,15 @@ class EBMModel(BaseEstimator):
         check_is_fitted(self, "has_fitted_")
 
         # If terms contains term names, convert them to indices
-        terms = [self.term_names_.index(term) if isinstance(term, str) 
-                else term for term in terms]
+        terms = [
+            self.term_names_.index(term) if isinstance(term, str) else term
+            for term in terms
+        ]
 
         def _remove_indices(x, idx):
             # Remove elements of a list based on provided index
             return [i for j, i in enumerate(x) if j not in idx]
+
         term_features = _remove_indices(self.term_features_, idx=terms)
         term_names = _remove_indices(self.term_names_, idx=terms)
         term_scores = _remove_indices(self.term_scores_, idx=terms)
@@ -2185,26 +2188,26 @@ class EBMModel(BaseEstimator):
         return self
 
     def scale_terms(self, weights, remove_nil_terms=False):
-        """Scale the individual term contributions by a constant multiple. For 
-        example, you can nullify the contribution of specific terms by setting 
-        their corresponding weights to zero; this would cause the associated 
-        global explanations (e.g., variable importance) to also be zero. A 
-        couple of things are worth noting: 1) this method has no affect on the 
-        fitted intercept and users will have to change that attribute directly 
-        (if desired), and 2) reweighting specific term contributions will also 
-        reweight their related components in a similar manner (e.g., variable 
+        """Scale the individual term contributions by a constant multiple. For
+        example, you can nullify the contribution of specific terms by setting
+        their corresponding weights to zero; this would cause the associated
+        global explanations (e.g., variable importance) to also be zero. A
+        couple of things are worth noting: 1) this method has no affect on the
+        fitted intercept and users will have to change that attribute directly
+        (if desired), and 2) reweighting specific term contributions will also
+        reweight their related components in a similar manner (e.g., variable
         importance scores, standard deviations, etc.).
 
         Args:
-            weights: A list of weights (one weight for each term in the model). 
-                This should be a list or numpy vector (i.e., 1-d array) of 
+            weights: A list of weights (one weight for each term in the model).
+                This should be a list or numpy vector (i.e., 1-d array) of
                 floats whose i-th element corresponds to the i-th element of the
                 ``.term_*_`` attributes (e.g., ``.term_names_``).
             remove_nil_terms: Boolean indicating whether or not to automatically
                 remove all terms that are given a weight of zero; terms with a
                 weight of zero provide zero contribution to the fit.
 
-        Returns: 
+        Returns:
             Itself.
         """
         check_is_fitted(self, "has_fitted_")
@@ -2220,7 +2223,6 @@ class EBMModel(BaseEstimator):
         standard_deviations = self.standard_deviations_.copy()
 
         for idw, w in enumerate(weights):
-
             scores = term_scores[idw].copy()
             bscores = bagged_scores[idw].copy()
             stdevs = standard_deviations[idw].copy()
@@ -2229,7 +2231,7 @@ class EBMModel(BaseEstimator):
             y_sd = stdevs
 
             # Reweight relevant components by scalar multiple given by weight
-            y *= w  
+            y *= w
             y_bagged *= w
             y_sd *= w
 

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2207,7 +2207,7 @@ class EBMModel(BaseEstimator):
                 This should be a list or numpy vector (i.e., 1-d array) of 
                 floats whose i-th element corresponds to the i-th element of the
                 ``.term_*_`` attributes (e.g., ``.term_names_``).
-            remove_nil_terms: Logical indicating whether or not to automatically
+            remove_nil_terms: Boolean indicating whether or not to automatically
                 remove all terms that are given a weight of zero; terms with a
                 weight of zero provide zero contribution to the fit.
 

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2184,15 +2184,16 @@ class EBMModel(BaseEstimator):
 
         return self
 
-    def reweight_terms(self, weights, remove_nil_terms=False):
-        """Reweight the individual term contributions. For example, you can 
-        nullify the contribution of specific terms by setting their corresponding 
-        weights to zero; this would cause the associated global explanations (e.g.,
-        variable importance) to also be zero. A couple of things are worth noting: 
-        1) this method has no affect on the fitted intercept and users will have to 
-        change that attribute directly if desired, and 2) reweighting specific term 
-        contributions will also reweight their related components in a similar 
-        manner (e.g., variable importance scores, standard deviations, etc.).
+    def scale_terms(self, weights, remove_nil_terms=False):
+        """Scale the individual term contributions by a constant multiple. For 
+        example, you can nullify the contribution of specific terms by setting 
+        their corresponding weights to zero; this would cause the associated 
+        global explanations (e.g., variable importance) to also be zero. A 
+        couple of things are worth noting: 1) this method has no affect on the 
+        fitted intercept and users will have to change that attribute directly 
+        (if desired), and 2) reweighting specific term contributions will also 
+        reweight their related components in a similar manner (e.g., variable 
+        importance scores, standard deviations, etc.).
 
         Args:
             weights: A list of weights (one weight for each term in the model). 

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2217,6 +2217,9 @@ class EBMModel(BaseEstimator):
             _log.error(msg)
             raise ValueError(msg)
 
+        if isinstance(weights, list):
+            weights = np.array(weights)
+
         # Copy any fields we'll overwrite in case someone has a shallow copy of self
         term_scores = self.term_scores_.copy()
         bagged_scores = self.bagged_scores_.copy()

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2145,7 +2145,7 @@ class EBMModel(BaseEstimator):
 
         return self
 
-    def remove_terms(self, term_list):
+    def remove_terms(self, terms):
         """Removes terms (and their associated components) from a fitted EBM. Note 
         that this will change the structure (i.e., by removing the specified 
         indices) of the following components of ``self``: ``term_features_``,
@@ -2153,16 +2153,16 @@ class EBMModel(BaseEstimator):
         ``standard_deviations_``, and ``bin_weights_``.
 
         Args:
-            term_list: A list of term names or indices.
+            terms: A list (or other enumerable object) of term names or indices.
 
         Returns:
             Itself.
         """
         check_is_fitted(self, "has_fitted_")
 
-        # If term_list contains term names, convert them to indices
-        term_list = [self.term_names_.index(term) if isinstance(term, str) 
-                    else term for term in term_list]
+        # If terms contains term names, convert them to indices
+        terms = [self.term_names_.index(term) if isinstance(term, str) 
+                else term for term in terms]
 
         # Copy any fields we'll overwrite in case someone has a shallow copy of self
         term_features = self.term_features_.copy()
@@ -2175,12 +2175,12 @@ class EBMModel(BaseEstimator):
         def _remove_indices(x, idx):
             # Remove elements of a list based on provided index
             return [i for j, i in enumerate(x) if j not in idx]
-        term_features = _remove_indices(term_features, idx=term_list)
-        term_names = _remove_indices(term_names, idx=term_list)
-        term_scores = _remove_indices(term_scores, idx=term_list)
-        bagged_scores = _remove_indices(bagged_scores, idx=term_list)
-        standard_deviations = _remove_indices(standard_deviations, idx=term_list)
-        bin_weights = _remove_indices(bin_weights, idx=term_list)
+        term_features = _remove_indices(term_features, idx=terms)
+        term_names = _remove_indices(term_names, idx=terms)
+        term_scores = _remove_indices(term_scores, idx=terms)
+        bagged_scores = _remove_indices(bagged_scores, idx=terms)
+        standard_deviations = _remove_indices(standard_deviations, idx=terms)
+        bin_weights = _remove_indices(bin_weights, idx=terms)
 
         # Update components of self
         self.term_features_ = term_features
@@ -2263,8 +2263,8 @@ class EBMModel(BaseEstimator):
         # Delete "nil" terms (i.e., terms providing zero contribution to the fit)
         if remove_nil_terms:  # should automatically catch zero weight terms
             # Delete components that have a weight of zero
-            term_list = np.where(weights == 0)[0].tolist()
-            return self.remove_terms(term_list)
+            terms = np.where(weights == 0)[0].tolist()
+            return self.remove_terms(terms)
         else:
             return self
 

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2187,8 +2187,8 @@ class EBMModel(BaseEstimator):
 
         return self
 
-    def scale_terms(self, weights, remove_nil_terms=False):
-        """Scale the individual term contributions by a constant multiple. For
+    def scale_terms(self, factors, remove_nil_terms=False):
+        """Scale the individual term contributions by a constant factor. For
         example, you can nullify the contribution of specific terms by setting
         their corresponding weights to zero; this would cause the associated
         global explanations (e.g., variable importance) to also be zero. A
@@ -2199,7 +2199,7 @@ class EBMModel(BaseEstimator):
         importance scores, standard deviations, etc.).
 
         Args:
-            weights: A list of weights (one weight for each term in the model).
+            factors: A list of weights/factors (one for each term in the model).
                 This should be a list or numpy vector (i.e., 1-d array) of
                 floats whose i-th element corresponds to the i-th element of the
                 ``.term_*_`` attributes (e.g., ``.term_names_``).
@@ -2212,20 +2212,20 @@ class EBMModel(BaseEstimator):
         """
         check_is_fitted(self, "has_fitted_")
 
-        if len(weights) != len(self.term_names_):
+        if len(factors) != len(self.term_names_):
             msg = "need to supply one weight for each term"
             _log.error(msg)
             raise ValueError(msg)
 
-        if isinstance(weights, list):
-            weights = np.array(weights)
+        if isinstance(factors, list):
+            factors = np.array(factors)
 
         # Copy any fields we'll overwrite in case someone has a shallow copy of self
         term_scores = self.term_scores_.copy()
         bagged_scores = self.bagged_scores_.copy()
         standard_deviations = self.standard_deviations_.copy()
 
-        for idw, w in enumerate(weights):
+        for idw, w in enumerate(factors):
             scores = term_scores[idw].copy()
             bscores = bagged_scores[idw].copy()
             stdevs = standard_deviations[idw].copy()
@@ -2253,7 +2253,7 @@ class EBMModel(BaseEstimator):
         # Delete "nil" terms (i.e., terms providing zero contribution to the fit)
         if remove_nil_terms:  # should automatically catch zero weight terms
             # Delete components that have a weight of zero
-            terms = np.where(weights == 0)[0].tolist()
+            terms = np.where(factors == 0)[0].tolist()
             return self.remove_terms(terms)
         else:
             return self

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2223,31 +2223,26 @@ class EBMModel(BaseEstimator):
             scores = term_scores[idw].copy()
             bscores = bagged_scores[idw].copy()
             stdevs = standard_deviations[idw].copy()
-            # FIXME: Does it make sense to omit the missing and unknown bins (first 
-            # and last elements, respectively)?
-            y = scores[1:-1]
-            y_bagged = bscores[1:-1]
-            y_sd = stdevs[1:-1]
+            y = scores
+            y_bagged = bscores
+            y_sd = stdevs
 
             # Reweight relevant components by scalar multiple given by weight
             y *= w  
             y_bagged *= w
             y_sd *= w
 
-            scores[1:-1] = y
-            bscores[1:-1] = y_bagged
-            stdevs[1:-1] = y_sd
+            scores = y
+            bscores = y_bagged
+            stdevs = y_sd
             term_scores[idw] = scores
             bagged_scores[idw] = bscores
             standard_deviations[idw] = stdevs
 
         # Update components of self
-        self.term_features_ = term_features
-        self.term_names_ = term_names
         self.term_scores_ = term_scores
         self.bagged_scores_ = bagged_scores
         self.standard_deviations_ = standard_deviations
-        self.bin_weights_ = bin_weights
 
         # Delete "nil" terms (i.e., terms providing zero contribution to the fit)
         if remove_nil_terms:  # should automatically catch zero weight terms

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2214,11 +2214,8 @@ class EBMModel(BaseEstimator):
             raise ValueError(msg)
 
         # Copy any fields we'll overwrite in case someone has a shallow copy of self
-        term_features = self.term_features_.copy()
-        term_names = self.term_names_.copy()
         term_scores = self.term_scores_.copy()
         bagged_scores = self.bagged_scores_.copy()
-        bin_weights = self.bin_weights_.copy()
         standard_deviations = self.standard_deviations_.copy()
 
         for idw, w in enumerate(weights):

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2164,23 +2164,15 @@ class EBMModel(BaseEstimator):
         terms = [self.term_names_.index(term) if isinstance(term, str) 
                 else term for term in terms]
 
-        # Copy any fields we'll overwrite in case someone has a shallow copy of self
-        term_features = self.term_features_.copy()
-        term_names = self.term_names_.copy()
-        term_scores = self.term_scores_.copy()
-        bagged_scores = self.bagged_scores_.copy()
-        bin_weights = self.bin_weights_.copy()
-        standard_deviations = self.standard_deviations_.copy()
-
         def _remove_indices(x, idx):
             # Remove elements of a list based on provided index
             return [i for j, i in enumerate(x) if j not in idx]
-        term_features = _remove_indices(term_features, idx=terms)
-        term_names = _remove_indices(term_names, idx=terms)
-        term_scores = _remove_indices(term_scores, idx=terms)
-        bagged_scores = _remove_indices(bagged_scores, idx=terms)
-        standard_deviations = _remove_indices(standard_deviations, idx=terms)
-        bin_weights = _remove_indices(bin_weights, idx=terms)
+        term_features = _remove_indices(self.term_features_, idx=terms)
+        term_names = _remove_indices(self.term_names_, idx=terms)
+        term_scores = _remove_indices(self.term_scores_, idx=terms)
+        bagged_scores = _remove_indices(self.bagged_scores_, idx=terms)
+        standard_deviations = _remove_indices(self.standard_deviations_, idx=terms)
+        bin_weights = _remove_indices(self.bin_weights_, idx=terms)
 
         # Update components of self
         self.term_features_ = term_features

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -1066,3 +1066,42 @@ def test_exclude_all():
     clf.predict(X)
 
     assert len(clf.term_features_) == 0
+
+def test_ebm_remove_terms():
+    data = synthetic_regression()
+    X = data["full"]["X"]
+    y = data["full"]["y"]
+
+    clf = ExplainableBoostingRegressor(n_jobs=-2, interactions=0)
+    clf.fit(X, y)
+    assert clf.term_names_ == ["A", "B", "C", "D"]
+    clf.remove_terms(["A", "C"])   
+    assert clf.term_names_ == ["B", "D"]
+    assert len(clf.term_features_) == 2
+    assert len(clf.term_names_) == 2
+    assert len(clf.term_scores_) == 2
+    assert len(clf.bagged_scores_) == 2
+    assert len(clf.standard_deviations_) == 2
+    assert len(clf.bin_weights_) == 2
+
+    valid_ebm(clf)
+
+def test_ebm_scale_terms():
+    data = synthetic_regression()
+    X = data["full"]["X"]
+    y = data["full"]["y"]
+
+    clf = ExplainableBoostingRegressor(n_jobs=-2, interactions=0)
+    clf.fit(X, y)
+    assert clf.term_names_ == ["A", "B", "C", "D"]
+    # The following is equivalent to calling `clf.remove_terms(["A", "C"])`
+    clf.scale_terms(weights=[0, 1.0, 0, 1.0], remove_nil_terms=True)   
+    assert clf.term_names_ == ["B", "D"]
+    assert len(clf.term_features_) == 2
+    assert len(clf.term_names_) == 2
+    assert len(clf.term_scores_) == 2
+    assert len(clf.bagged_scores_) == 2
+    assert len(clf.standard_deviations_) == 2
+    assert len(clf.bin_weights_) == 2
+
+    valid_ebm(clf)

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -1038,14 +1038,13 @@ def test_exclude_implicit():
 
     valid_ebm(clf)
 
+
 def test_exclude_complete_feature():
     data = synthetic_regression()
     X = data["full"]["X"]
     y = data["full"]["y"]
 
-    clf = ExplainableBoostingRegressor(
-        interactions=[], exclude=[0, 1]
-    )
+    clf = ExplainableBoostingRegressor(interactions=[], exclude=[0, 1])
     clf.fit(X, y)
     clf.predict(X)
 
@@ -1054,18 +1053,18 @@ def test_exclude_complete_feature():
     assert (2,) in clf.term_features_
     assert (3,) in clf.term_features_
 
+
 def test_exclude_all():
     data = synthetic_regression()
     X = data["full"]["X"]
     y = data["full"]["y"]
 
-    clf = ExplainableBoostingRegressor(
-        interactions=[], exclude="mains"
-    )
+    clf = ExplainableBoostingRegressor(interactions=[], exclude="mains")
     clf.fit(X, y)
     clf.predict(X)
 
     assert len(clf.term_features_) == 0
+
 
 def test_ebm_remove_terms():
     data = synthetic_regression()
@@ -1075,7 +1074,7 @@ def test_ebm_remove_terms():
     clf = ExplainableBoostingRegressor(n_jobs=-2, interactions=0)
     clf.fit(X, y)
     assert clf.term_names_ == ["A", "B", "C", "D"]
-    clf.remove_terms(["A", "C"])   
+    clf.remove_terms(["A", "C"])
     assert clf.term_names_ == ["B", "D"]
     assert len(clf.term_features_) == 2
     assert len(clf.term_names_) == 2
@@ -1086,6 +1085,7 @@ def test_ebm_remove_terms():
 
     valid_ebm(clf)
 
+
 def test_ebm_scale_terms():
     data = synthetic_regression()
     X = data["full"]["X"]
@@ -1095,7 +1095,7 @@ def test_ebm_scale_terms():
     clf.fit(X, y)
     assert clf.term_names_ == ["A", "B", "C", "D"]
     # The following is equivalent to calling `clf.remove_terms(["A", "C"])`
-    clf.scale_terms(weights=[0, 1.0, 0, 1.0], remove_nil_terms=True)   
+    clf.scale_terms(weights=[0, 1.0, 0, 1.0], remove_nil_terms=True)
     assert clf.term_names_ == ["B", "D"]
     assert len(clf.term_features_) == 2
     assert len(clf.term_names_) == 2

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -1093,7 +1093,7 @@ def test_ebm_scale_terms():
     clf.fit(X, y)
     assert clf.term_names_ == ["A", "B", "C", "D"]
     # The following is equivalent to calling `clf.remove_terms(["A", "C"])`
-    clf.scale_terms(weights=[0, 1.0, 0, 1.0], remove_nil_terms=True)
+    clf.scale_terms(factors=[0, 1.0, 0, 1.0], remove_nil_terms=True)
     assert clf.term_names_ == ["B", "D"]
     assert len(clf.term_features_) == 2
     assert len(clf.term_names_) == 2

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -1083,8 +1083,6 @@ def test_ebm_remove_terms():
     assert len(clf.standard_deviations_) == 2
     assert len(clf.bin_weights_) == 2
 
-    valid_ebm(clf)
-
 
 def test_ebm_scale_terms():
     data = synthetic_regression()
@@ -1103,5 +1101,3 @@ def test_ebm_scale_terms():
     assert len(clf.bagged_scores_) == 2
     assert len(clf.standard_deviations_) == 2
     assert len(clf.bin_weights_) == 2
-
-    valid_ebm(clf)


### PR DESCRIPTION
This PR addresses https://github.com/interpretml/interpret/issues/460 by adding two new methods to a fitted EBM object: 
* `reweight_terms()` - which allows callers to reweight the individual term contributions of the fit;
* `remove_terms()` - which allows callers to remove specific terms (and their associated components).