### PR TITLE
BUG: define missing logger objects

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_json.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_json.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 The InterpretML Contributors
 # Distributed under the MIT software license
-
+import logging
 from warnings import warn
 from ...utils._link import identify_task
 from math import isnan
@@ -11,6 +11,8 @@ from ._utils import generate_term_names
 from ...utils._histogram import make_all_histogram_edges
 
 from ...utils._clean_simple import typify_classification
+
+_log = logging.getLogger(__name__)
 
 
 def jsonify_lists(vals):

--- a/python/interpret-core/interpret/utils/_misc.py
+++ b/python/interpret-core/interpret/utils/_misc.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2023 The InterpretML Contributors
 # Distributed under the MIT software license
-
+import logging
 from itertools import count
 import numpy as np
+
+_log = logging.getLogger(__name__)
 
 
 def clean_index(index, n_items, names, param_name, attribute_name):


### PR DESCRIPTION
There are missing `_log` objects in some modules, which causes errors.