### PR TITLE
Fix minor difference between docstring and actual function

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2126,6 +2126,8 @@ class EBMModel(BaseEstimator):
             _log.error(msg)
             raise ValueError(msg)
 
+        return self
+
     def scale(self, term, factor):
         """Scale the individual term contribution by a constant factor. For
         example, you can nullify the contribution of specific terms by setting


### PR DESCRIPTION
In the [docs](https://interpret.ml/docs/python/api/ExplainableBoostingClassifier.html#interpret.glassbox.ExplainableBoostingClassifier.sweep), the sweep function is supposed to return itself, but none is returned. Added a return statement