### PR TITLE
MAINT: Rebase EBM utils

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_utils.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_utils.py
@@ -309,6 +309,8 @@ def deduplicate_bins(bins):
 
 def convert_to_intervals(cuts):  # pragma: no cover
     cuts = np.array(cuts, dtype=np.float64)
+    if cuts.size == 0:
+        return [(-np.inf, np.inf)]
 
     if not np.isfinite(cuts).all():
         raise Exception("cuts must contain only finite numbers")

--- a/python/interpret-core/interpret/glassbox/_ebm/_utils.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_utils.py
@@ -1,17 +1,16 @@
 # Copyright (c) 2023 The InterpretML Contributors
 # Distributed under the MIT software license
 
+import logging
+import warnings
 from collections import defaultdict
-from math import ceil, isinf, exp, log, isfinite
-from ...utils._native import Native
-
-from ._tensor import restore_missing_value_zeros
+from itertools import islice
+from math import ceil, exp, isfinite, isinf, log
 
 import numpy as np
-import warnings
-from itertools import islice
 
-import logging
+from ...utils._native import Native
+from ._tensor import restore_missing_value_zeros
 
 _log = logging.getLogger(__name__)
 

--- a/python/interpret-core/interpret/glassbox/_ebm/_utils.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_utils.py
@@ -165,8 +165,7 @@ def process_bag_terms(n_classes, term_scores, bin_weights):
             temp_scores = scores.flatten().copy()
             temp_weights = weights.flatten().copy()
 
-            ignored = np.isinf(temp_scores)
-            ignored |= np.isnan(temp_scores)
+            ignored = ~np.isfinite(temp_scores)
             temp_scores[ignored] = 0.0
             temp_weights[ignored] = 0.0
 
@@ -179,8 +178,7 @@ def process_bag_terms(n_classes, term_scores, bin_weights):
                 temp_scores = scores[..., i].flatten().copy()
                 temp_weights = weights.flatten().copy()
 
-                ignored = np.isinf(temp_scores)
-                ignored |= np.isnan(temp_scores)
+                ignored = ~np.isfinite(temp_scores)
                 temp_scores[ignored] = 0.0
                 temp_weights[ignored] = 0.0
 
@@ -312,11 +310,8 @@ def deduplicate_bins(bins):
 def convert_to_intervals(cuts):  # pragma: no cover
     cuts = np.array(cuts, dtype=np.float64)
 
-    if np.isnan(cuts).any():
-        raise Exception("cuts cannot contain nan")
-
-    if np.isinf(cuts).any():
-        raise Exception("cuts cannot contain infinity")
+    if not np.isfinite(cuts).all():
+        raise Exception("cuts must contain only finite numbers")
 
     intervals = [(-np.inf, cuts[0]), *zip(cuts[:-1], cuts[1:]), (cuts[-1], np.inf)]
 

--- a/python/interpret-core/interpret/glassbox/_ebm/_utils.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_utils.py
@@ -376,40 +376,39 @@ def make_bag(y, test_size, rng, is_stratified):
     # if we re-generate the train/test splits that they are generated exactly
     # the same as before
 
+    if test_size < 0:  # pragma: no cover
+        raise Exception("test_size must be a positive numeric value.")
     if test_size == 0:
         return None
-    elif test_size > 0:
-        n_samples = len(y)
-        n_test_samples = 0
+    n_samples = len(y)
+    n_test_samples = 0
 
-        if test_size >= 1:
-            if test_size % 1:
-                raise Exception(
-                    "If test_size >= 1, test_size should be a whole number."
-                )
-            n_test_samples = test_size
-        else:
-            n_test_samples = ceil(n_samples * test_size)
-
-        n_train_samples = n_samples - n_test_samples
-        native = Native.get_native_singleton()
-
-        # Adapt test size if too small relative to number of classes
-        if is_stratified:
-            n_classes = len(set(y))
-            if n_test_samples < n_classes:  # pragma: no cover
-                warnings.warn(
-                    "Too few samples per class, adapting test size to guarantee 1 sample per class."
-                )
-                n_test_samples = n_classes
-                n_train_samples = n_samples - n_test_samples
-
-            return native.sample_without_replacement_stratified(
-                rng, n_classes, n_train_samples, n_test_samples, y
+    if test_size >= 1:
+        if test_size % 1:
+            raise Exception(
+                "If test_size >= 1, test_size should be a whole number."
             )
-        else:
-            return native.sample_without_replacement(
-                rng, n_train_samples, n_test_samples
+        n_test_samples = test_size
+    else:
+        n_test_samples = ceil(n_samples * test_size)
+
+    n_train_samples = n_samples - n_test_samples
+    native = Native.get_native_singleton()
+
+    # Adapt test size if too small relative to number of classes
+    if is_stratified:
+        n_classes = len(set(y))
+        if n_test_samples < n_classes:  # pragma: no cover
+            warnings.warn(
+                "Too few samples per class, adapting test size to guarantee 1 sample per class."
             )
-    else:  # pragma: no cover
-        raise Exception("test_size must be a positive numeric value.")
+            n_test_samples = n_classes
+            n_train_samples = n_samples - n_test_samples
+
+        return native.sample_without_replacement_stratified(
+            rng, n_classes, n_train_samples, n_test_samples, y
+        )
+    else:
+        return native.sample_without_replacement(
+            rng, n_train_samples, n_test_samples
+        )

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm_utils.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm_utils.py
@@ -2,6 +2,8 @@ from math import ceil, floor
 from interpret.glassbox._ebm._utils import (
     make_bag,
     convert_categorical_to_continuous,
+    convert_to_cuts,
+    convert_to_intervals,
     _create_proportional_tensor,
     deduplicate_bins,
 )
@@ -31,6 +33,19 @@ def test_deduplicate_bins():
     assert id(bins[1][0]) != id(bins[1][1])
     assert id(bins[1][0]) == id(bins[1][2])
     assert id(bins[1][1]) != id(bins[1][2])
+
+
+def test_conversion_cut_intervals():
+    """Minimal test with roundtrip."""
+    # cuts -> intervals -> cuts
+    for cuts, intervals in [
+        ([1, 2], [(float("-inf"), 1.0), (1.0, 2.0), (2.0, float("inf"))]),
+        ([], [(float("-inf"), float("inf"))])
+    ]:
+        to_interval = convert_to_intervals(cuts)
+        assert to_interval == intervals
+        cut_rountrip = convert_to_cuts(to_interval)
+        assert cut_rountrip == cuts
 
 
 @pytest.mark.skip(reason="make_bag test needs to be updated")


### PR DESCRIPTION
Simplify the utility functions in the EBM utils.
- reduce code duplication
- reduce complexity by early returns
- explicitly unpack tuples of two elements
- refactor methods
- use dedicated functions of libraries