### PR TITLE
TST: loosen requirements for scikit-learn tests

### DIFF
--- a/python/interpret-core/setup.py
+++ b/python/interpret-core/setup.py
@@ -240,7 +240,7 @@ https://github.com/interpretml/interpret
         "numpy>=1.11.1",
         "scipy>=0.18.1",
         "pandas>=0.19.2",
-        "scikit-learn>=0.24",
+        "scikit-learn>=0.18.1",
         "joblib>=0.11",
     ],
     extras_require={
@@ -268,6 +268,7 @@ https://github.com/interpretml/interpret
         ],
         # Testing
         "testing": [
+            "scikit-learn>=1.0.0",
             "pytest>=4.3.0",
             "pytest-runner>=4.4",
             "pytest-xdist>=1.29",

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -917,21 +917,20 @@ _fast_kwds = {
 @pytest.fixture
 def skip_sklearn() -> set:
     """Test which we do not adhere to."""
-    ec = estimator_checks
     return {
-        ec.check_sample_weights_invariance,  # EBMs do not support sample weight=0
+        "check_sample_weights_invariance",  # EBMs do not support sample weight=0
         # EBM allows fitting to zero features. Is this meaningful?
-        ec.check_estimators_empty_data_messages,
+        "check_estimators_empty_data_messages",
         # test is bad, trained on floats, EBM predicts string labels
         # test fails as 1.0 != "1.0", maybe test should be fixed upstream?
-        ec.check_classifiers_one_label,
-        ec.check_classifiers_one_label_sample_weights,  # EBMs do not accept sample weight of 0
-        ec.check_fit1d,  # EBMs accept 1d X for single feature
-        ec.check_fit2d_predict1d,  # EBMs accept 1d for predict
+        "check_classifiers_one_label",
+        "check_classifiers_one_label_sample_weights",  # EBMs do not accept sample weight of 0
+        "check_fit1d",  # EBMs accept 1d X for single feature
+        "check_fit2d_predict1d",  # EBMs accept 1d for predict
         # EBM is more permissive and convert any y values to str
-        ec.check_classifiers_regression_target,
-        ec.check_supervised_y_2d,  # EBM deliberately support `y.shape = (nsamples, 1)`
-        ec.check_requires_y_none,  # error message differs
+        "check_classifiers_regression_target",
+        "check_supervised_y_2d",  # EBM deliberately support `y.shape = (nsamples, 1)`
+        "check_requires_y_none",  # error message differs
     }
 
 
@@ -942,7 +941,7 @@ def skip_sklearn() -> set:
     # DPExplainableBoostingRegressor(**_fast_kwds),
 ])
 def test_sklearn_estimator(estimator, check, skip_sklearn):
-    if check.func in skip_sklearn:
+    if check.func.__name__ in skip_sklearn:
         pytest.skip("Deliberate deviation from scikit-learn.")
     with warnings.catch_warnings():
         warnings.filterwarnings(


### PR DESCRIPTION
This is a fixup for #518 
We only need an up-to-date version for running tests, not for usage of the library.

Furthermore, it is a bit more robust to skip tests based on names instead of comparing functions. This avoids errors, if test aren't available yet in older versions of `scikit-learn`.

---

Sorry for this fixup, these issues slipped my mind when I create the original PR...