### PR TITLE
BUG: Fix index error when values exceed 999T

### DIFF
--- a/python/interpret-core/interpret/visual/plot.py
+++ b/python/interpret-core/interpret/visual/plot.py
@@ -215,9 +215,7 @@ def _human_format(num):
     while abs(num) >= 1000:
         magnitude += 1
         num /= 1000.0
-    return "{}{}".format(
-        f"{num:f}".rstrip("0").rstrip("."), suffixes[magnitude]
-    )
+    return "{}{}".format(f"{num:f}".rstrip("0").rstrip("."), suffixes[magnitude])
 
 
 # TODO: Clean this up after validation.

--- a/python/interpret-core/interpret/visual/plot.py
+++ b/python/interpret-core/interpret/visual/plot.py
@@ -203,14 +203,20 @@ def plot_continuous_bar(
 
 # Taken from:
 # https://stackoverflow.com/questions/579310/formatting-long-numbers-as-strings-in-python
+# Adapted to handle numbers larger than 1e15
 def _human_format(num):
     num = float(f"{num:.3g}")
     magnitude = 0
+    suffixes = ["", "K", "M", "B", "T"]
+
+    if abs(num) >= 1000 ** (len(suffixes)):  # 1000 ^ 5 == 1e15
+        return f"{num:.2e}"
+
     while abs(num) >= 1000:
         magnitude += 1
         num /= 1000.0
     return "{}{}".format(
-        f"{num:f}".rstrip("0").rstrip("."), ["", "K", "M", "B", "T"][magnitude]
+        f"{num:f}".rstrip("0").rstrip("."), suffixes[magnitude]
     )
 
 

--- a/python/interpret-core/tests/visual/test_plot.py
+++ b/python/interpret-core/tests/visual/test_plot.py
@@ -4,6 +4,7 @@
 from interpret.visual.plot import plot_line
 from interpret.visual.plot import plot_density
 
+
 def test_plot_line_bounds_smoke():
     data_dict = {
         "names": ["a", "b", "c"],
@@ -14,17 +15,18 @@ def test_plot_line_bounds_smoke():
     figure = plot_line(data_dict)
     assert figure.data[0].name == "Lower Bound"
 
+
 def test_plot_density_large_numbers():
     """
     Test that density plots handle large numbers correctly using the new number formatting
     """
     data_dict = {
         "scores": [1.0, 1.0],
-        "names": [9e13, 1e14, 1e15]  # 1e15 value will trigger new formatting
+        "names": [9e13, 1e14, 1e15],  # 1e15 value will trigger new formatting
     }
-    
+
     figure = plot_density(data_dict)
-    
+
     # The x-axis tick text should show ranges using our new formatting
     assert "90T - 100T" in figure.layout.xaxis.ticktext[0]
     assert "100T - 1.00e+15" in figure.layout.xaxis.ticktext[1]

--- a/python/interpret-core/tests/visual/test_plot.py
+++ b/python/interpret-core/tests/visual/test_plot.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license
 
 from interpret.visual.plot import plot_line
-
+from interpret.visual.plot import plot_density
 
 def test_plot_line_bounds_smoke():
     data_dict = {
@@ -13,3 +13,18 @@ def test_plot_line_bounds_smoke():
     }
     figure = plot_line(data_dict)
     assert figure.data[0].name == "Lower Bound"
+
+def test_plot_density_large_numbers():
+    """
+    Test that density plots handle large numbers correctly using the new number formatting
+    """
+    data_dict = {
+        "scores": [1.0, 1.0],
+        "names": [9e13, 1e14, 1e15]  # 1e15 value will trigger new formatting
+    }
+    
+    figure = plot_density(data_dict)
+    
+    # The x-axis tick text should show ranges using our new formatting
+    assert "90T - 100T" in figure.layout.xaxis.ticktext[0]
+    assert "100T - 1.00e+15" in figure.layout.xaxis.ticktext[1]


### PR DESCRIPTION
Hi!

This PR is an intended fix of the bug presented in issue #370. I fixed the IndexError by falling back to using the scientific notation once values become larger than 999T. I also added a test case which tests that exact functionality and with this modification I was able to solve the IndexError.

