### PR TITLE
ENHANCEMENT: Add a prediction function that also calculates uncertainty in the prediction

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2271,6 +2271,10 @@ class EBMModel(BaseEstimator):
                 First column contains mean predictions (probabilities)
                 Second column contains uncertainties (standard deviations)
         """
+        if self.max_bins != self.max_interaction_bins:
+            msg = "pred_from_base_models_with_uncertainty is not supported for models with different max_bins and max_interaction_bins"
+            _log.error(msg)
+            raise ValueError(msg)
 
         binned_inst = self._preprocessor.transform(instances)
         preds_per_bag = np.zeros(shape=(instances.shape[0], len(self.bagged_scores_)))

--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -2269,13 +2269,14 @@ class EBMModel(BaseEstimator):
                 First column contains mean predictions
                 Second column contains uncertainties
         """
+        check_is_fitted(self, "has_fitted_")
+
         X, n_samples = preclean_X(
             instances, self.feature_names_in_, self.feature_types_in_
         )
-        preds_per_bag = np.zeros((n_samples, len(self.bagged_scores_)))
-
+        preds_per_bag = np.zeros((n_samples, len(self.bagged_intercept_)))
         # Get predictions from each bagged model
-        for bag_index in range(len(self.bagged_scores_)):
+        for bag_index in range(len(self.bagged_intercept_)):
             # Use slices from bagged parameters for this specific model
             scores = ebm_predict_scores(
                 X=X,

--- a/python/interpret-core/interpret/utils/_preprocessor.py
+++ b/python/interpret-core/interpret/utils/_preprocessor.py
@@ -485,7 +485,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                         # X_col could be a slice that has a stride.  We need contiguous for caling into C
                         X_col = X_col.copy()
 
-                    X_col = native.discretize(X_col, bins)
+                    X_col = native.discretize(X_col, bins[-1])
 
                 if np.count_nonzero(X_col) != len(X_col):
                     msg = "missing values in X not supported in transform"
@@ -550,6 +550,8 @@ def construct_bins(
     privacy_bounds=None,
 ):
     is_mains = True
+    main_preprocessor = None
+
     for max_bins in max_bins_leveled:
         preprocessor = EBMPreprocessor(
             feature_names_given,
@@ -566,7 +568,6 @@ def construct_bins(
         )
 
         seed = increment_seed(seed)
-
         preprocessor.fit(X, y, sample_weight)
         if is_mains:
             is_mains = False
@@ -582,6 +583,8 @@ def construct_bins(
             missing_val_counts = preprocessor.missing_val_counts_
             unique_val_counts = preprocessor.unique_val_counts_
             noise_scale = preprocessor.noise_scale_
+            main_preprocessor = preprocessor
+
         else:
             if feature_names_in != preprocessor.feature_names_in_:
                 msg = "Mismatched feature_names"
@@ -606,4 +609,5 @@ def construct_bins(
         missing_val_counts,
         unique_val_counts,
         noise_scale,
+        main_preprocessor,
     )

--- a/python/interpret-core/interpret/utils/_preprocessor.py
+++ b/python/interpret-core/interpret/utils/_preprocessor.py
@@ -485,7 +485,7 @@ class EBMPreprocessor(BaseEstimator, TransformerMixin):
                         # X_col could be a slice that has a stride.  We need contiguous for caling into C
                         X_col = X_col.copy()
 
-                    X_col = native.discretize(X_col, bins[-1])
+                    X_col = native.discretize(X_col, bins)
 
                 if np.count_nonzero(X_col) != len(X_col):
                     msg = "missing values in X not supported in transform"
@@ -550,7 +550,6 @@ def construct_bins(
     privacy_bounds=None,
 ):
     is_mains = True
-    main_preprocessor = None
 
     for max_bins in max_bins_leveled:
         preprocessor = EBMPreprocessor(
@@ -583,7 +582,6 @@ def construct_bins(
             missing_val_counts = preprocessor.missing_val_counts_
             unique_val_counts = preprocessor.unique_val_counts_
             noise_scale = preprocessor.noise_scale_
-            main_preprocessor = preprocessor
 
         else:
             if feature_names_in != preprocessor.feature_names_in_:
@@ -609,5 +607,4 @@ def construct_bins(
         missing_val_counts,
         unique_val_counts,
         noise_scale,
-        main_preprocessor,
     )

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm.py
@@ -1191,13 +1191,8 @@ def test_ebm_uncertainty():
         result_same_seed,
     ), "Results should be deterministic with same random seed"
 
-    X_far = X.copy()
-    X_far["A"] = X_far["A"] + 10.0  # Shift first feature far from training data
-    preds_far = clf.pred_from_base_models_with_uncertainty(X_far)
-
-    assert np.mean(preds_far[:, 1]) > np.mean(
-        result[:, 1]
-    ), "Uncertainty should be higher for points far from training data"
+    mean_predictions = result[:, 0]
+    assert np.all(np.isfinite(mean_predictions)), "All predictions should be finite"
 
     uncertainties = result[:, 1]
     assert np.all(uncertainties >= 0), "Uncertainties should be non-negative"


### PR DESCRIPTION
This PR intends to fix issue #235. Since release v0.3.0 individual bagged models are stored inside the EBM which made it possible to create a prediction function that also calculates uncertainty by calculating the mean and standard deviation across bags (as suggested in the issue #235 by @interpret-ml).

Since this issue was created, some implementation details were changed and I was not able to access the transform function from EBMPreprocessor anymore. Therefore I edited the function construct_bins in _preprocessor.py to return the main_preprocessor and then safe it as class attribute in EBMModel. 

I am not sure if it should be kept this way because an earlier release removed this attribute from EBMModel, but I do not know how else to access the functionality of the transform method (except duplicating it). I would be happy about guidance regarding this.

Another implementation detail which has changed was the structure of bins in the transform function, which threw an error when calling the discretize function. I fixed this by always accessing the last element in the bins list, but I am also happy about guidance here for cleaner or more robust solutions.

Last but not least, this currently only works if max_bins == max_interaction_bins, so at the moment I am just informing the user when calling that these attributes have to be equal.

I also tested the uncertainty estimates on the breast cancer dataset from sklearn and have attached the plot I made to this PR. I think it looks good :)
![Figure_1](https://github.com/user-attachments/assets/c46b7c35-516d-46e1-bc4a-24b6c5a9d19c)
