### PR TITLE
BUG: fix compatibility with NumPy 2.3

### DIFF
--- a/python/interpret-core/interpret/utils/_compressed_dataset.py
+++ b/python/interpret-core/interpret/utils/_compressed_dataset.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 
 from ._clean_x import categorical_encode, unify_columns
-from ._native import Native, _boolebm_t
+from ._native import Native
 
 _log = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ def bin_native(
 
         n_bytes += native.measure_feature(
             n_bins,
-            _boolebm_t(np.count_nonzero(X_col) != len(X_col)),
+            np.count_nonzero(X_col) != len(X_col),
             bad is not None,
             feature_type == "nominal",
             X_col,
@@ -134,7 +134,7 @@ def bin_native(
 
         native.fill_feature(
             n_bins,
-            _boolebm_t(np.count_nonzero(X_col) != len(X_col)),
+            np.count_nonzero(X_col) != len(X_col),
             bad is not None,
             feature_type == "nominal",
             X_col,

--- a/python/interpret-core/interpret/utils/_compressed_dataset.py
+++ b/python/interpret-core/interpret/utils/_compressed_dataset.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 
 from ._clean_x import categorical_encode, unify_columns
-from ._native import Native
+from ._native import Native, _boolebm_t
 
 _log = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ def bin_native(
 
         n_bytes += native.measure_feature(
             n_bins,
-            np.count_nonzero(X_col) != len(X_col),
+            _boolebm_t(np.count_nonzero(X_col) != len(X_col)),
             bad is not None,
             feature_type == "nominal",
             X_col,
@@ -134,7 +134,7 @@ def bin_native(
 
         native.fill_feature(
             n_bins,
-            np.count_nonzero(X_col) != len(X_col),
+            _boolebm_t(np.count_nonzero(X_col) != len(X_col)),
             bad is not None,
             feature_type == "nominal",
             X_col,

--- a/python/interpret-core/interpret/utils/_compressed_dataset.py
+++ b/python/interpret-core/interpret/utils/_compressed_dataset.py
@@ -5,7 +5,7 @@ import logging
 
 import numpy as np
 
-from ._clean_x import unify_columns, categorical_encode
+from ._clean_x import categorical_encode, unify_columns
 from ._native import Native
 
 _log = logging.getLogger(__name__)

--- a/python/interpret-core/interpret/utils/_native.py
+++ b/python/interpret-core/interpret/utils/_native.py
@@ -15,6 +15,8 @@ import numpy as np
 
 _log = logging.getLogger(__name__)
 
+_boolebm_t = np.int32
+
 
 class Native:
     # see notes in libebm.h on the maximum representable int64 in float64 format

--- a/python/interpret-core/interpret/utils/_native.py
+++ b/python/interpret-core/interpret/utils/_native.py
@@ -8,7 +8,6 @@ import os
 import platform
 import struct
 import sys
-import math
 from contextlib import AbstractContextManager
 from math import prod
 

--- a/python/interpret-core/interpret/utils/_native.py
+++ b/python/interpret-core/interpret/utils/_native.py
@@ -15,7 +15,13 @@ import numpy as np
 
 _log = logging.getLogger(__name__)
 
-_boolebm_t = np.int32
+
+def _boolebm(val):
+    """Convert `bool` to `np.int32` used by libebm to represents `bool`."""
+    if not isinstance(val, (bool, np.bool_)):
+        msg = f"Native EBM functions expect boolean, got f{type(val)}"
+        raise TypeError(msg)
+    return np.int32(val)
 
 
 class Native:
@@ -575,7 +581,7 @@ class Native:
             X_col.shape[0],
             Native._make_pointer(X_col, np.float64),
             min_samples_bin,
-            is_rounded,
+            _boolebm(is_rounded),
             ct.byref(count_cuts),
             Native._make_pointer(cuts, np.float64),
         )
@@ -658,9 +664,9 @@ class Native:
     def measure_feature(self, n_bins, is_missing, is_unseen, is_nominal, bin_indexes):
         n_bytes = self._unsafe.MeasureFeature(
             n_bins,
-            is_missing,
-            is_unseen,
-            is_nominal,
+            _boolebm(is_missing),
+            _boolebm(is_unseen),
+            _boolebm(is_nominal),
             len(bin_indexes),
             Native._make_pointer(bin_indexes, np.int64),
         )
@@ -712,9 +718,9 @@ class Native:
     ):
         return_code = self._unsafe.FillFeature(
             n_bins,
-            is_missing,
-            is_unseen,
-            is_nominal,
+            _boolebm(is_missing),
+            _boolebm(is_unseen),
+            _boolebm(is_nominal),
             len(bin_indexes),
             Native._make_pointer(bin_indexes, np.int64),
             dataset.nbytes,

--- a/python/interpret-core/tests/glassbox/ebm/test_ebm_exact.py
+++ b/python/interpret-core/tests/glassbox/ebm/test_ebm_exact.py
@@ -58,7 +58,7 @@ def test_identical_ebm():
 
             seed += 1
 
-    expected = 3.293830243001896e+19
+    expected = 3.293830243001896e19
 
     assert fingerprint == expected
 


### PR DESCRIPTION
The C++ data type `BoolEBM` is defined as `int32_t`, thus an integer not a `np.bool_` should be passed to these functions.

NumPy 2.3 removes following behavior:

* ‘np.bool’ scalars can no longer be interpreted as an index (deprecated since 1.19)
  ([gh-28254](https://github.com/numpy/numpy/pull/28254))

I assume that due to this pending deprecation previously it was allowed to pass a `bool` as an `int32_t` as it could be interpreted as index and therefore as number.

-------

Note the subtle difference: Python's `bool` is a `numbers.Integral` and `numbers.Number`:

```Python
>> import numbers
>> isinstance(True, numbers.Integral)
True
>> isinstance(True, numbers.Number)
True
>> True + True
2
```

But `np.bool_` is not:
```python
>> import numpy as np
>> isinstance(np.bool_(True), numbers.Integral)
False
>> isinstance(np.bool_(True), numbers.Number)
False
```

Neither, Python's `bool` nor NumPy's `np.bool_` are NumPy integers or numbers:
```python
>> isinstance(np.True_, np.integer)
False
>> isinstance(np.True, np.number)
False
>> np.True_ + np.True_
np.True_
```

NumPy's `bool` corresponds to `bool` defined in stdbool.h.

------

FYI: as you work with `cytpes`: NumPy offers also some convenience functions to handle pointers and arrays, as well as a platform independent `load_library` implementation.
https://numpy.org/doc/stable/reference/routines.ctypeslib.html