### PR TITLE
docs: typo fix

### DIFF
--- a/docs/interpret/framework.ipynb
+++ b/docs/interpret/framework.ipynb
@@ -13,7 +13,7 @@
    "id": "armed-trustee",
    "metadata": {},
    "source": [
-    "The visualizations that power `interpret` use different renderers depending on the environment they are in. In most cases, the package will detect what kind of environment it is in and use the appropriat [renderer](https://github.com/interpretml/interpret/blob/683e632f4122af54eada2e214066de7be75bd7e0/python/interpret-core/interpret/provider/visualize.py#L25). There are times though when you want to forcefully select which one."
+    "The visualizations that power `interpret` use different renderers depending on the environment they are in. In most cases, the package will detect what kind of environment it is in and use the appropriate [renderer](https://github.com/interpretml/interpret/blob/683e632f4122af54eada2e214066de7be75bd7e0/python/interpret-core/interpret/provider/visualize.py#L25). There are times though when you want to forcefully select which one."
    ]
   },
   {


### PR DESCRIPTION
Corrected "appropriat" to appropriate" in `framework.ipynb`