### PR TITLE
MNT: use builtin nsmallest

### DIFF
--- a/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
+++ b/python/interpret-core/interpret/glassbox/_ebm/_ebm.py
@@ -1348,7 +1348,9 @@ class EBMModel(ExplainerMixin, BaseEstimator):
                                 )
 
                         boost_groups = heapq.nsmallest(
-                            interactions, pair_ranks, key=lambda idx: pair_ranks[idx]
+                            interactions,
+                            pair_ranks,
+                            key=lambda indices: (pair_ranks[indices], indices),
                         )
                     else:
                         # Check and remove duplicate interaction terms


### PR DESCRIPTION
As far as I can tell, the code simply reimplements the `nsmallest` function available in the standard library. 