### PR TITLE
Add license information to setup.py

### DIFF
--- a/python/interpret-core/setup.py
+++ b/python/interpret-core/setup.py
@@ -136,6 +136,7 @@ Minimal dependency core system for the interpret package.
 https://github.com/interpretml/interpret
 """,
     long_description_content_type="text/plain",
+    license="MIT",
     url="https://github.com/interpretml/interpret",
     cmdclass={
         "sdist": SDistCommand,

--- a/python/interpret/setup.py
+++ b/python/interpret/setup.py
@@ -35,6 +35,7 @@ setup(
     description="Fit interpretable models. Explain blackbox machine learning.",
     long_description=long_description,
     long_description_content_type="text/plain",
+    license='MIT',
     url="https://github.com/interpretml/interpret",
     packages=find_packages(),
     classifiers=[

--- a/python/interpret/setup.py
+++ b/python/interpret/setup.py
@@ -35,7 +35,7 @@ setup(
     description="Fit interpretable models. Explain blackbox machine learning.",
     long_description=long_description,
     long_description_content_type="text/plain",
-    license='MIT',
+    license="MIT",
     url="https://github.com/interpretml/interpret",
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Fixes license specifier according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

This allows automatic license inspection tools like pip-licenses to correctly categorize this package.