### PR TITLE
blackbox: warn when LimeTabular ignores user-supplied mode (#477)

### DIFF
--- a/python/interpret-core/interpret/blackbox/_lime.py
+++ b/python/interpret-core/interpret/blackbox/_lime.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023 The InterpretML Contributors
 # Distributed under the MIT software license
 
+import warnings
+
 import numpy as np
 
 from ..core.base import LocalExplainer
@@ -46,8 +48,26 @@ class LimeTabular(LocalExplainer):
         # so convert to np.float64 until we implement some automatic categorical handling
         data = data.astype(np.float64, order="C", copy=False)
 
-        # rewrite these even if the user specified them
+        # `LimeTabular` always runs the underlying LIME explainer in
+        # "regression" mode regardless of whether the wrapped model is a
+        # regressor or a binary classifier — `unify_predict_fn` below
+        # turns classifier outputs into a scalar probability in [0, 1] so
+        # LIME treats both cases uniformly. The overrides for `mode` and
+        # `feature_names` are therefore intentional, but issue #477 showed
+        # they are surprising when a user sets `mode="classification"`
+        # explicitly. Warn if their value is being discarded so they know
+        # to read the docstring rather than wonder why nothing happened.
         kwargs = kwargs.copy()
+        user_mode = kwargs.get("mode", "regression")
+        if user_mode != "regression":
+            warnings.warn(
+                "LimeTabular wraps LIME in 'regression' mode internally for "
+                "both regression and binary classification (the predict "
+                "function is unified to return a scalar). The "
+                f"`mode={user_mode!r}` argument was ignored.",
+                UserWarning,
+                stacklevel=2,
+            )
         kwargs["mode"] = "regression"
         kwargs["feature_names"] = self.feature_names_in_
 

--- a/python/interpret-core/tests/blackbox/test_lime.py
+++ b/python/interpret-core/tests/blackbox/test_lime.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 The InterpretML Contributors
+# Distributed under the MIT software license
+
+"""Tests for LimeTabular wrapper.
+
+Issue #477: passing ``mode="classification"`` to ``LimeTabular`` was
+silently overridden to ``"regression"`` because the wrapper unifies
+classifier and regressor predict functions to a scalar. The override is
+intentional (LIME wouldn't otherwise work with the unified predict
+path), but a silent override is surprising — users were left wondering
+why the keyword had no effect. The wrapper now emits a UserWarning when
+a non-default ``mode`` is discarded.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+pytest.importorskip("lime")
+
+from interpret.blackbox import LimeTabular
+
+
+def _toy_data():
+    rng = np.random.default_rng(0)
+    return rng.standard_normal((20, 3)).astype(np.float64)
+
+
+def _toy_predict_fn(X):
+    # Probability of class 1 — what LimeTabular's unify_predict_fn yields
+    # for a binary classifier.
+    return 1.0 / (1.0 + np.exp(-X.sum(axis=1)))
+
+
+def test_user_supplied_mode_classification_warns():
+    # BEFORE: passing mode="classification" was silently overridden.
+    # AFTER: a UserWarning is emitted that mentions the override.
+    data = _toy_data()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LimeTabular(
+            model=_toy_predict_fn,
+            data=data,
+            mode="classification",
+        )
+    user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user_warnings) == 1, [str(w.message) for w in caught]
+    assert "regression" in str(user_warnings[0].message).lower()
+    assert "classification" in str(user_warnings[0].message).lower()
+
+
+def test_no_warning_when_mode_omitted():
+    # The default path (no mode kwarg) must stay quiet — we don't want to
+    # nag every user who follows the documented API.
+    data = _toy_data()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LimeTabular(model=_toy_predict_fn, data=data)
+    user_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "mode=" in str(w.message)
+    ]
+    assert user_warnings == []
+
+
+def test_no_warning_when_mode_regression():
+    # Explicitly passing the value we use internally must also stay quiet.
+    data = _toy_data()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LimeTabular(model=_toy_predict_fn, data=data, mode="regression")
+    user_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "mode=" in str(w.message)
+    ]
+    assert user_warnings == []


### PR DESCRIPTION
## Summary

`LimeTabular(model=..., data=..., mode="classification")` silently drops
the user-supplied `mode` argument and runs LIME in `"regression"` mode
instead. The override is necessary (the wrapper unifies classifier
predict functions to a scalar so LIME can treat them uniformly), but
silence makes it confusing — users were left wondering why their
keyword had no effect (issue #477). Emit a `UserWarning` when the
override actually changes anything, so the behaviour stays the same
but the surprise is gone.

Fixes interpretml/interpret#477 — *Why the "mode" in lime is fixed to "regression"?*

## Context

In `_lime.py` the wrapper does:

```python
# rewrite these even if the user specified them
kwargs = kwargs.copy()
kwargs["mode"] = "regression"
kwargs["feature_names"] = self.feature_names_in_
```

The forced `"regression"` is intentional: `unify_predict_fn(predict_fn, X, 1
if n_classes == 2 else -1)` turns a classifier into something that returns
a scalar probability, and LIME-in-classification-mode would expect a 2D
probability array. Running LIME in regression mode is what makes the
wrapper work for both regression and binary classification.

That is fine. What is **not** fine is dropping the user's `mode` kwarg
without a peep: `LimeTabular(..., mode="classification")` looked like it
would do something and did nothing. This PR keeps the override but
emits a `UserWarning` only when the user actually passed a different
value. The silent path (no `mode`, or explicit `mode="regression"`)
stays warning-free so we don't nag people who follow the documented
API.

## Changes

- `python/interpret-core/interpret/blackbox/_lime.py`
  - import `warnings`
  - before applying the override, check whether `kwargs["mode"]` is
    already `"regression"`. If not, emit a `UserWarning` mentioning the
    user's value and explaining why the wrapper forces regression mode.
  - the inline comment on the override is rewritten to call out the
    invariant explicitly (citing issue #477) so a future maintainer
    doesn't have to re-derive why this guard exists.
- `python/interpret-core/tests/blackbox/test_lime.py` (new)
  - three pytest cases: warning on `mode="classification"`, no warning
    when `mode` is omitted, no warning when the user explicitly passes
    `mode="regression"`. The first case fails on `origin/main`.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/interpretml/interpret.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e "python/interpret-core[lime]"

cat > /tmp/repro_477.py <<'PY'
import warnings
import numpy as np
from interpret.blackbox import LimeTabular

rng = np.random.default_rng(0)
data = rng.standard_normal((20, 3)).astype(np.float64)

def predict_fn(X):
    return 1.0 / (1.0 + np.exp(-X.sum(axis=1)))

with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    LimeTabular(model=predict_fn, data=data, mode="classification")

mode_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
print(f"warnings emitted: {len(mode_warnings)}")
for w in mode_warnings:
    print(f"  - {w.message}")
PY

# --- BEFORE (origin/main) ---
git checkout origin/main
python /tmp/repro_477.py
# Expected: "warnings emitted: 0" — the override is silent

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/interpret.git feat/477-lime-mode-warn-override
git checkout FETCH_HEAD
python /tmp/repro_477.py
# Expected: "warnings emitted: 1" with a message mentioning both
#           "regression" and "classification"
```

## What I ran locally

- `python -m pytest -vv tests/blackbox/test_lime.py` → **3 passed** on
  this branch; **1 failed, 2 passed** on `origin/main` (the failing
  case is the warning assertion — exactly the divergence this PR
  introduces).
- `ruff check interpret-core/interpret/blackbox/_lime.py` → 1 error,
  identical to `origin/main` (`PLC0415` on the existing `from lime…`
  inline import; pre-existing, not touched by this PR).
- `ruff format --check` on the touched files → already formatted.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `mode="classification"` | user kwarg differs from internal default | UserWarning emitted, message mentions both modes | `test_user_supplied_mode_classification_warns` |
| 2 | `mode` omitted | default path | zero warnings about `mode=` | `test_no_warning_when_mode_omitted` |
| 3 | `mode="regression"` (explicit) | user matches internal default | zero warnings — no override happening | `test_no_warning_when_mode_regression` |

## Risk / blast radius

The override behaviour is unchanged; existing user code keeps working.
The only new artefact is a `UserWarning` on a path that was previously
silent. Anyone who was unknowingly relying on the silent-override
behaviour will now see a single warning explaining what happened, then
the wrapper continues exactly as before.

## Release note

```release-note
LimeTabular now warns when the user-supplied `mode` kwarg is overridden
to "regression" (issue #477). The override behaviour itself is
unchanged.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against `interpretml/interpret`'s source and the cited issue.
The reproducer block above was used during development; it is the same
one a reviewer can paste verbatim.*
